### PR TITLE
fix sign-to-contract

### DIFF
--- a/btclib/ecsigntocontract.py
+++ b/btclib/ecsigntocontract.py
@@ -25,7 +25,6 @@ COMMITMENT VERIFICATION:
 from hashlib import sha256
 from btclib.ellipticcurves import secp256k1 as ec
 from btclib.rfc6979 import rfc6979
-from btclib.ecsignutils import int_from_hash
 from btclib.wifaddress import int_from_prvkey
 from btclib.ecdsa import ecdsa_sign, ecdsa_verify, check_dsasig, ecdsa_sign_raw
 from btclib.ecssa import ecssa_sign, ecssa_verify, check_ssasig, ecssa_sign_raw

--- a/btclib/ecsigntocontract.py
+++ b/btclib/ecsigntocontract.py
@@ -38,7 +38,7 @@ def tweak(k, c, hasher=sha256):
     - tweaked private key k + h(kG||c), the corresponding pubkey is a commitment to kG, c
     """
     R = ec.pointMultiply(k, ec.G)
-    e = hasher(ec.bytes_from_point(R) + c).digest()
+    e = hasher(ec.bytes_from_point(R, True) + c).digest()
     e = int.from_bytes(e, 'big')
     return R, (e + k) % ec.order
 
@@ -64,7 +64,7 @@ def verify_commit(receipt, c, hasher=sha256):
     w, R = receipt
     ec.y(w, False)  # receipt[0] is valid iif its y does exist
     ec.tuple_from_point(R)  # verify it is a good point
-    e = hasher(ec.bytes_from_point(R) + c).digest()
+    e = hasher(ec.bytes_from_point(R, True) + c).digest()
     e = int.from_bytes(e, 'big')
     W = ec.pointAdd(R, ec.pointMultiply(e, ec.G))
     return w % ec.order == W[0] % ec.order

--- a/btclib/ecsigntocontract.py
+++ b/btclib/ecsigntocontract.py
@@ -12,14 +12,14 @@ HOW:
   when signing, generate a nonce (k) and compute a EC point (R = kG)
   instead of proceeding using (k,R), compute a value (e) that is a
   commitment to c:
-    e = hash(R.x||c)
+    e = hash(R||c)
   substitute the nonce k with k+e and R with R+eG, and proceed signing
   in the standard way, using (k+e,R+eG).
 COMMITMENT VERIFICATION:
   the verifier can see W.x (W = R+eG) on the signature
   the signer (and committer) provides R and c
   the verifier checks that:   W.x = (R+eG).x
-                              (with e = hash(R.x||c))
+                              (with e = hash(R||c))
 """
 
 from hashlib import sha256
@@ -39,8 +39,8 @@ def tweak(k, c, hasher=sha256):
     - tweaked private key k + h(kG||c), the corresponding pubkey is a commitment to kG, c
     """
     R = ec.pointMultiply(k, ec.G)
-    e = hasher(R[0].to_bytes(32, 'big') + c).digest()
-    e = int_from_hash(e, ec.order)
+    e = hasher(ec.bytes_from_point(R) + c).digest()
+    e = int.from_bytes(e, 'big')
     return R, (e + k) % ec.order
 
 def ecdsa_commit_and_sign(m, prv, c, eph_prv=None, hasher=sha256):
@@ -62,11 +62,11 @@ def ecssa_commit_and_sign(m, prv, c, eph_prv=None, hasher=sha256):
 # FIXME: have create_commit instead of ecdsa_commit_and_sign
 #                                  and ecssa_commit_and_sign
 def verify_commit(receipt, c, hasher=sha256):
-    ec.y(receipt[0], False) # receipt[0] is valid iif its y does exist
-    ec.tuple_from_point(receipt[1]) # verify it is a good point
     w, R = receipt
-    e = hasher(R[0].to_bytes(32, 'big') + c).digest()
-    e = int_from_hash(e, ec.order)
+    ec.y(w, False)  # receipt[0] is valid iif its y does exist
+    ec.tuple_from_point(R)  # verify it is a good point
+    e = hasher(ec.bytes_from_point(R) + c).digest()
+    e = int.from_bytes(e, 'big')
     W = ec.pointAdd(R, ec.pointMultiply(e, ec.G))
     return w % ec.order == W[0] % ec.order
     # weaker verfication! w in [1..ec.order-1] dsa


### PR DESCRIPTION
*sign-to-contract* commits the point, not only its x coord.

Moreover, unlike the hash computed in the signature, it does not need `int_from_hash()`.