### PR TITLE
Make Schnorr adherent to BIP

### DIFF
--- a/btclib/ecssa.py
+++ b/btclib/ecssa.py
@@ -9,12 +9,16 @@ from btclib.ellipticcurves import Union, Tuple, Optional, \
                                   Point as PubKey, GenericPoint as GenericPubKey, \
                                   mod_inv, \
                                   secp256k1 as ec, \
-                                  int_from_Scalar, tuple_from_Point
+                                  int_from_Scalar, tuple_from_Point, bytes_from_Point
 from btclib.rfc6979 import rfc6979
 from btclib.ecsignutils import Message, Signature, int_from_hash
 
 # %% ecssa sign
-# https://github.com/sipa/secp256k1/blob/968e2f415a5e764d159ee03e95815ea11460854e/src/modules/schnorr/schnorr.md
+# https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki
+
+
+def jacobi(x):
+    return pow(x, (ec._EllipticCurve__prime - 1) // 2, ec._EllipticCurve__prime)
 
 # different structure, cannot compute e (int) before ecssa_sign_raw
 
@@ -27,14 +31,15 @@ def ecssa_sign(m: Message, prvkey: PrvKey, eph_prv: Optional[PrvKey] = None, has
 # https://eprint.iacr.org/2018/068
 def ecssa_sign_raw(m: bytes, prvkey: int, eph_prv: int, hasher = sha256) -> Signature:
     R = ec.pointMultiply(eph_prv, ec.G)
-    if R[1] % 2 == 1:
-        eph_prv = ec.order - eph_prv  # <=> R_y = ec_prime - R_y
-    r = R[0] % ec.order # % ec.order ?
-    e = hasher(R[0].to_bytes(32, 'big') + m).digest()
+    if jacobi(R[1]) != 1:
+        eph_prv = ec.order - eph_prv  # iff R[1] = ec.p - R[1]
+    e = hasher(R[0].to_bytes(32, byteorder="big") +
+               bytes_from_Point(ec, ec.pointMultiply(prvkey, ec.G), True) +
+               m).digest()
     e = int_from_hash(e, ec.order)
     assert e != 0 and e < ec.order, "sign fail"
-    s = (eph_prv - e * prvkey) % ec.order
-    return r, s
+    s = (eph_prv + e * prvkey) % ec.order
+    return R[0], s
 
 
 def ecssa_verify(m: Message, ssasig: Signature, pubkey: GenericPubKey, hasher = sha256) -> bool:
@@ -45,32 +50,33 @@ def ecssa_verify(m: Message, ssasig: Signature, pubkey: GenericPubKey, hasher = 
 
 
 def ecssa_verify_raw(m: bytes, ssasig: Signature, pub: PubKey, hasher = sha256) -> bool:
-    R_x, s = ssasig[0].to_bytes(32, 'big'), ssasig[1]
-    e = hasher(R_x + m).digest()
+    r, s = ssasig
+    e = hasher(r.to_bytes(32, byteorder="big") + bytes_from_Point(ec, pub, True) + m).digest()
     e = int_from_hash(e, ec.order)
-    if e == 0 or e >= ec.order: return False
-    R = ec.pointAdd(ec.pointMultiply(e, pub), ec.pointMultiply(s, ec.G))
-    if R[1] % 2 == 1:  # R.y odd
+    if e == 0 or e >= ec.order:
+        return False
+    R = ec.pointAdd(ec.pointMultiply(ec.order - e, pub), ec.pointMultiply(s, ec.G))
+    if jacobi(R[1]) != 1:
         return False
     return R[0] == ssasig[0]
 
 
-def ecssa_pubkey_recovery(m: Message, ssasig: Signature, hasher = sha256) -> PubKey:
-    if type(m) == str: m = hasher(m.encode()).digest()
+def ecssa_pubkey_recovery(e: bytes, ssasig: Signature, hasher = sha256) -> PubKey:
+    assert len(e) == 32
     check_ssasig(ssasig)
-    return ecssa_pubkey_recovery_raw(m, ssasig, hasher) # FIXME: this is just the message hasher
+    return ecssa_pubkey_recovery_raw(e, ssasig) # FIXME: this is just the message hasher
 
 
-def ecssa_pubkey_recovery_raw(m: bytes, ssasig: Signature, hasher = sha256) -> PubKey:
-    R_x, s = ssasig
-    R = (R_x, ec.y(R_x, 0))
-    R_x = R_x.to_bytes(32, 'big')
-    e = hasher(R_x + m).digest()
+def ecssa_pubkey_recovery_raw(e: bytes, ssasig: Signature) -> PubKey:
+    r, s = ssasig
+    R = (r, ec.y(r, 0))
+    if jacobi(R[1]) != 1:
+        R = (R[0], ec._EllipticCurve__prime - R[1])
     e = int_from_hash(e, ec.order)
-    assert e != 0 and e < ec.order, "invalid e value"
+    assert e != 0 and e < ec.order, "invalid challenge e"
     e1 = mod_inv(e, ec.order)
-    return ec.pointAdd(ec.pointMultiply(e1, R),
-                       ec.pointMultiply(-e1 * s % ec.order, ec.G))
+    return ec.pointAdd(ec.pointMultiply((e1 * s) % ec.order, ec.G),
+                       ec.pointMultiply(ec.order - e1, R))
 
 
 def check_ssasig(ssasig: Signature) -> bool:
@@ -81,5 +87,6 @@ def check_ssasig(ssasig: Signature) -> bool:
            "ssasig must be a tuple of 2 int"
     # TODO: maybe new ec.is_x_valid(x) method
     ec.y(ssasig[0], False) # R.x is valid iif R.y does exist
+    assert 0 < ssasig[0] and ssasig[0] < ec._EllipticCurve__prime, "r must be in [1..prime]"
     assert 0 < ssasig[1] and ssasig[1] < ec.order, "s must be in [1..order]"
     return True

--- a/btclib/ecssa.py
+++ b/btclib/ecssa.py
@@ -87,6 +87,5 @@ def check_ssasig(ssasig: Signature) -> bool:
            "ssasig must be a tuple of 2 int"
     # TODO: maybe new ec.is_x_valid(x) method
     ec.y(ssasig[0], False) # R.x is valid iif R.y does exist
-    assert 0 < ssasig[0] and ssasig[0] < ec._EllipticCurve__prime, "r must be in [1..prime]"
     assert 0 < ssasig[1] and ssasig[1] < ec.order, "s must be in [1..order]"
     return True

--- a/tests/test_ecssa.py
+++ b/tests/test_ecssa.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
 import unittest
+from hashlib import sha256
+from btclib.ellipticcurves import bytes_from_Point
 from btclib.ecssa import ec, ecssa_sign, ecssa_verify, ecssa_pubkey_recovery
+
 
 class TestEcssa(unittest.TestCase):
     def test_ecssa(self):
@@ -15,7 +18,31 @@ class TestEcssa(unittest.TestCase):
         malleated_sig = (ssasig[0], ec.order - ssasig[1])
         self.assertFalse(ecssa_verify(msg, malleated_sig, pub))
 
-        self.assertEqual(ecssa_pubkey_recovery(msg, ssasig), pub)
+        e = sha256(ssasig[0].to_bytes(32, byteorder="big") +
+                   bytes_from_Point(ec, pub, True) +
+                   sha256(msg.encode()).digest()).digest()
+        self.assertEqual(ecssa_pubkey_recovery(e, ssasig), pub)
+
+    def test_ecssa_bip(self):
+        prv = 0x1
+        pub = ec.pointMultiply(prv, ec.G)
+        msg = b'\x00' * 32
+        expected_sig = (0x787A848E71043D280C50470E8E1532B2DD5D20EE912A45DBDD2BD1DFBF187EF6,
+                        0x7031A98831859DC34DFFEEDDA86831842CCD0079E1F92AF177F7F22CC1DCED05)
+        eph_prv = int.from_bytes(sha256(prv.to_bytes(32, byteorder="big") + msg).digest(), byteorder="big")
+
+        sig = ecssa_sign(msg, prv, eph_prv)
+        self.assertTrue(ecssa_verify(msg, sig, pub))
+        # malleability
+        malleated_sig = (sig[0], ec.order - sig[1])
+        self.assertFalse(ecssa_verify(msg, malleated_sig, pub))
+
+        self.assertEqual(sig, expected_sig)
+
+        e = sha256(sig[0].to_bytes(32, byteorder="big") +
+                   bytes_from_Point(ec, pub, True) +
+                   msg).digest()
+        self.assertEqual(ecssa_pubkey_recovery(e, sig), pub)
 
 
 if __name__ == "__main__":

--- a/tests/test_ecssa.py
+++ b/tests/test_ecssa.py
@@ -2,28 +2,12 @@
 
 import unittest
 from hashlib import sha256
-from btclib.ellipticcurves import bytes_from_Point
+from btclib.ellipticcurves import bytes_from_Point, tuple_from_Point
 from btclib.ecssa import ec, ecssa_sign, ecssa_verify, ecssa_pubkey_recovery
 
 
 class TestEcssa(unittest.TestCase):
-    def test_ecssa(self):
-        prv = 0x1
-        pub = ec.pointMultiply(prv, ec.G)
-        msg = 'Satoshi Nakamoto'
-
-        ssasig = ecssa_sign(msg, prv)
-        self.assertTrue(ecssa_verify(msg, ssasig, pub))
-        # malleability
-        malleated_sig = (ssasig[0], ec.order - ssasig[1])
-        self.assertFalse(ecssa_verify(msg, malleated_sig, pub))
-
-        e = sha256(ssasig[0].to_bytes(32, byteorder="big") +
-                   bytes_from_Point(ec, pub, True) +
-                   sha256(msg.encode()).digest()).digest()
-        self.assertEqual(ecssa_pubkey_recovery(e, ssasig), pub)
-
-    def test_ecssa_bip(self):
+    def test_ecssa_1(self):
         prv = 0x1
         pub = ec.pointMultiply(prv, ec.G)
         msg = b'\x00' * 32
@@ -34,15 +18,98 @@ class TestEcssa(unittest.TestCase):
         sig = ecssa_sign(msg, prv, eph_prv)
         self.assertTrue(ecssa_verify(msg, sig, pub))
         # malleability
-        malleated_sig = (sig[0], ec.order - sig[1])
-        self.assertFalse(ecssa_verify(msg, malleated_sig, pub))
-
+        self.assertFalse(ecssa_verify(msg, (sig[0], ec.order - sig[1]), pub))
         self.assertEqual(sig, expected_sig)
-
         e = sha256(sig[0].to_bytes(32, byteorder="big") +
                    bytes_from_Point(ec, pub, True) +
                    msg).digest()
         self.assertEqual(ecssa_pubkey_recovery(e, sig), pub)
+
+    def test_ecssa_2(self):
+        prv = 0xB7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF
+        pub = ec.pointMultiply(prv, ec.G)
+        msg = bytes.fromhex("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89")
+        expected_sig = (0x2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D,
+                        0x1E51A22CCEC35599B8F266912281F8365FFC2D035A230434A1A64DC59F7013FD)
+        eph_prv = int.from_bytes(sha256(prv.to_bytes(32, byteorder="big") + msg).digest(), byteorder="big")
+
+        sig = ecssa_sign(msg, prv, eph_prv)
+        self.assertTrue(ecssa_verify(msg, sig, pub))
+        # malleability
+        self.assertFalse(ecssa_verify(msg, (sig[0], ec.order - sig[1]), pub))
+        self.assertEqual(sig, expected_sig)
+        e = sha256(sig[0].to_bytes(32, byteorder="big") +
+                   bytes_from_Point(ec, pub, True) +
+                   msg).digest()
+        self.assertEqual(ecssa_pubkey_recovery(e, sig), pub)
+
+    def test_ecssa_3(self):
+        prv = 0xC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B14E5C7
+        pub = ec.pointMultiply(prv, ec.G)
+        msg = bytes.fromhex("5E2D58D8B3BCDF1ABADEC7829054F90DDA9805AAB56C77333024B9D0A508B75C")
+        expected_sig = (0x00DA9B08172A9B6F0466A2DEFD817F2D7AB437E0D253CB5395A963866B3574BE,
+                        0x00880371D01766935B92D2AB4CD5C8A2A5837EC57FED7660773A05F0DE142380)
+        eph_prv = int.from_bytes(sha256(prv.to_bytes(32, byteorder="big") + msg).digest(), byteorder="big")
+
+        sig = ecssa_sign(msg, prv, eph_prv)
+        self.assertTrue(ecssa_verify(msg, sig, pub))
+        # malleability
+        self.assertFalse(ecssa_verify(msg, (sig[0], ec.order - sig[1]), pub))
+        self.assertEqual(sig, expected_sig)
+        e = sha256(sig[0].to_bytes(32, byteorder="big") +
+                   bytes_from_Point(ec, pub, True) +
+                   msg).digest()
+        self.assertEqual(ecssa_pubkey_recovery(e, sig), pub)
+
+    def test_ecssa_4(self):
+        pub = tuple_from_Point(ec, "03DEFDEA4CDB677750A420FEE807EACF21EB9898AE79B9768766E4FAA04A2D4A34")
+        msg = bytes.fromhex("4DF3C3F68FCC83B27E9D42C90431A72499F17875C81A599B566C9889B9696703")
+        sig = (0x00000000000000000000003B78CE563F89A0ED9414F5AA28AD0D96D6795F9C63,
+               0x02A8DC32E64E86A333F20EF56EAC9BA30B7246D6D25E22ADB8C6BE1AEB08D49D)
+
+        self.assertTrue(ecssa_verify(msg, sig, pub))
+        # malleability
+        self.assertFalse(ecssa_verify(msg, (sig[0], ec.order - sig[1]), pub))
+        e = sha256(sig[0].to_bytes(32, byteorder="big") +
+                   bytes_from_Point(ec, pub, True) +
+                   msg).digest()
+        self.assertEqual(ecssa_pubkey_recovery(e, sig), pub)
+
+    def test_ecssa_5(self):
+        """Incorrect sig: incorrect R residuosity"""
+        pub = tuple_from_Point(ec, "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659")
+        msg = bytes.fromhex("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89")
+        sig = (0x2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D,
+               0xFA16AEE06609280A19B67A24E1977E4697712B5FD2943914ECD5F730901B4AB7)
+
+        self.assertFalse(ecssa_verify(msg, sig, pub))
+
+    def test_ecssa_6(self):
+        """Incorrect sig: negated message hash"""
+        pub = tuple_from_Point(ec, "03FAC2114C2FBB091527EB7C64ECB11F8021CB45E8E7809D3C0938E4B8C0E5F84B")
+        msg = bytes.fromhex("5E2D58D8B3BCDF1ABADEC7829054F90DDA9805AAB56C77333024B9D0A508B75C")
+        sig = (0x00DA9B08172A9B6F0466A2DEFD817F2D7AB437E0D253CB5395A963866B3574BE,
+               0xD092F9D860F1776A1F7412AD8A1EB50DACCC222BC8C0E26B2056DF2F273EFDEC)
+
+        self.assertFalse(ecssa_verify(msg, sig, pub))
+
+    def test_ecssa_7(self):
+        """Incorrect sig: negated s value"""
+        pub = tuple_from_Point(ec, "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798")
+        msg = b'\x00' * 32
+        sig = (0x787A848E71043D280C50470E8E1532B2DD5D20EE912A45DBDD2BD1DFBF187EF6,
+               0x8FCE5677CE7A623CB20011225797CE7A8DE1DC6CCD4F754A47DA6C600E59543C)
+
+        self.assertFalse(ecssa_verify(msg, sig, pub))
+
+    def test_ecssa_8(self):
+        """Incorrect sig: negated public key"""
+        pub = tuple_from_Point(ec, "03DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659")
+        msg = bytes.fromhex("243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89")
+        sig = (0x2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D,
+               0x1E51A22CCEC35599B8F266912281F8365FFC2D035A230434A1A64DC59F7013FD)
+
+        self.assertFalse(ecssa_verify(msg, sig, pub))
 
 
 if __name__ == "__main__":

--- a/tests/test_ecssamusig.py
+++ b/tests/test_ecssamusig.py
@@ -11,9 +11,10 @@ https://medium.com/@snigirev.stepan/how-schnorr-signatures-may-improve-bitcoin-9
 
 import unittest
 from btclib.ellipticcurves import int_from_Scalar, bytes_from_Point
-from btclib.ecssa import sha256, ec, int_from_hash, ecssa_verify
+from btclib.ecssa import sha256, ec, int_from_hash, ecssa_verify, jacobi
 
 class TestEcssaMuSig(unittest.TestCase):
+
     def test_ecssamusig(self):
         msg = 'message to sign'
         m = sha256(msg.encode()).digest()
@@ -26,8 +27,8 @@ class TestEcssaMuSig(unittest.TestCase):
 
         eph_prv1 = 0x012a2a833eac4e67e06611aba01345b85cdd4f5ad44f72e369ef0dd640424dbb
         R1 = ec.pointMultiply(eph_prv1, ec.G)
-        if R1[1] % 2 == 1: #must be even
-            eph_prv1 = ec.order - eph_prv1 
+        if jacobi(R1[1]) != 1:  # to break the symmetry, here another rule would be fine too
+            eph_prv1 = ec.order - eph_prv1
             R1 = ec.pointMultiply(eph_prv1, ec.G)
         R1_x = R1[0]
 
@@ -39,49 +40,54 @@ class TestEcssaMuSig(unittest.TestCase):
 
         eph_prv2 = 0x01a2a0d3eac4e67e06611aba01345b85cdd4f5ad44f72e369ef0dd640424dbdb
         R2 = ec.pointMultiply(eph_prv2, ec.G)
-        if R2[1] % 2 == 1: #must be even
+        if jacobi(R2[1]) != 1:  # to break the symmetry, here another rule would be fine too
             eph_prv2 = ec.order - eph_prv2
             R2 = ec.pointMultiply(eph_prv2, ec.G)
         R2_x = R2[0]
+
+        Q_All = ec.pointAdd(ec.pointMultiply(HQ1, Q1), ec.pointMultiply(HQ2, Q2))  # joint public key
 
         ######################
         # exchange Rx, compute s
         ######################
 
         # first signer use R2_x
-        R2_y_recovered = ec.y(R2_x, 0)   
-        R2_recovered = (R2_x, R2_y_recovered)
+        y = ec.y(R2_x, 0)
+        if jacobi(y) != 1:
+            y = ec._EllipticCurve__prime - y
+        R2_recovered = (R2_x, y)
         R1_All = ec.pointAdd(R1, R2_recovered)
-        if R1_All[1] % 2 == 1:      # must be even
+        if jacobi(R1_All[1]) != 1:  # necessary condition to create a valid schnorr signature
+            R1_All = (R1_All[0], ec._EllipticCurve__prime - R1_All[1])
             eph_prv1 = ec.order - eph_prv1
-        R1_All_x = R1_All[0].to_bytes(32, 'big')
-        e1 = int_from_hash(sha256(R1_All_x + m).digest(), ec.order)
+        e1 = int_from_hash(sha256(R1_All[0].to_bytes(32, byteorder="big") + bytes_from_Point(ec, Q_All, True) + m).digest(), ec.order)
         assert e1 != 0 and e1 < ec.order, "sign fail"
-        s1 = (eph_prv1 - e1 * prv1) % ec.order
+        s1 = (eph_prv1 + e1 * prv1) % ec.order
 
         # second signer use R1_x
-        R1_y_recovered = ec.y(R1_x, 0)
-        R1_recovered = (R1_x, R1_y_recovered)
+        y = ec.y(R1_x, 0)
+        if jacobi(y) != 1:
+            y = ec._EllipticCurve__prime - y
+        R1_recovered = (R1_x, y)
         R2_All = ec.pointAdd(R2, R1_recovered)
-        if R2_All[1] % 2 == 1:
+        if jacobi(R2_All[1]) != 1:  # necessary condition to create a valid schnorr signature
+            R2_All = (R2_All[0], ec._EllipticCurve__prime - R2_All[1])
             eph_prv2 = ec.order - eph_prv2
-        R2_All_x = R2_All[0].to_bytes(32, 'big')
-        e2 = int_from_hash(sha256(R2_All_x + m).digest(), ec.order)
+        e2 = int_from_hash(sha256(R2_All[0].to_bytes(32, byteorder="big") + bytes_from_Point(ec, Q_All, True) + m).digest(), ec.order)
         assert e2 != 0 and e2 < ec.order, "sign fail"
-        s2 = (eph_prv2 - e2 * prv2) % ec.order
+        s2 = (eph_prv2 + e2 * prv2) % ec.order
 
         ######################
         # combine signatures into a single signature
         ######################
 
         # anyone can do the following
-        assert R1_All_x == R2_All_x, "sign fail"
-        R_All_x = R1_All[0]
+        assert R1_All[0] == R2_All[0], "sign fail"
         s_All = (s1 + s2) % ec.order
-        ssasig = (R_All_x, s_All)
-        Q_All = ec.pointAdd(ec.pointMultiply(HQ1, Q1), ec.pointMultiply(HQ2, Q2))
+        ssasig = (R1_All[0], s_All)
 
         self.assertTrue(ecssa_verify(msg, ssasig, Q_All, sha256))
+
 
 if __name__ == "__main__":
     # execute only if run as a script


### PR DESCRIPTION
The Schnorr module `ecssa.py` should use the [recently proposed standard](https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki).

Some issues arises:
* `ec.prime` is needed, but now it is private.  In this PR it is used `ec._EllipticCurve__prime`. 
* `ecssa_pubkey_recovery` cannot work as before: to recover the pubkey from the signature `m` is not enough, it is necessary `e=h(R||P||m)`.
* `ecssa_verify` sometimes fails with an assertion error, sometimes returns False; this is a licit choice, but it is not consistent with the BIP specification.
* `test_ecssamusig.py` was using a different option to break the symmetry of the y-coord of `R`, thus it has to be changed to produce a valid Schnorr signature.