### PR TITLE
Modify int.from_bytes occurrences 

### DIFF
--- a/btclib/bip32.py
+++ b/btclib/bip32.py
@@ -45,7 +45,7 @@ def bip32_master_prvkey_from_seed(bip32_seed: Union[str, bytes], version: bytes)
 
     # actual extended key (key + chain code) derivation
     hashValue = HMAC(b"Bitcoin seed", bip32_seed, sha512).digest()
-    mprv = int.from_bytes(hashValue[:32], 'big') % ec.n
+    mprv = int_from_Scalar(ec, hashValue[:32])
     xmprv += hashValue[32:]                     # chain code
     xmprv += b'\x00' + mprv.to_bytes(32, 'big') # private key
 


### PR DESCRIPTION
Modifying int.from_bytes occurrence to int_from_Scalar according to the new library version.

Actually the modified occurrence seems (at least to me) to be the only for whom the update is needed as other occurrences' handling is meant to be dealt differently.