### PR TITLE
Signature on low cardinality curves

### DIFF
--- a/btclib/ecsigntocontract.py
+++ b/btclib/ecsigntocontract.py
@@ -56,7 +56,7 @@ def ecdsa_commit_and_sign(m: Message, prvkey: Scalar, c: Message, eph_prv: Optio
     # commit
     R, eph_prv = tweak(eph_prv, c, hasher)
     # sign
-    sig = ecdsa_sign_raw(m, prvkey, eph_prv)
+    sig = ecdsa_sign_raw(ec, m, prvkey, eph_prv)
     # commit receipt
     receipt = (sig[0], R)
     return sig, receipt
@@ -70,7 +70,7 @@ def ecssa_commit_and_sign(m: Message, prvkey: Scalar, c: Message, eph_prv: Optio
     # commit
     R, eph_prv = tweak(eph_prv, c, hasher)
     # sign
-    sig = ecssa_sign_raw(m, prvkey, eph_prv, hasher)
+    sig = ecssa_sign_raw(ec, m, prvkey, eph_prv, hasher)
     # commit receipt
     receipt = (sig[0], R)
     return sig, receipt

--- a/btclib/ecsignutils.py
+++ b/btclib/ecsignutils.py
@@ -8,7 +8,7 @@ Signature = Tuple[int, int]
 def int_from_hash(hash_digest, order, size=32):
     """from hash digest to int"""
     assert type(hash_digest) == bytes, "hash_digest must be bytes"
-    assert len(hash_digest) == size, "hash_digest must have correct bytes length"
+    assert len(hash_digest) <= size, "hash_digest must have correct bytes length"
     h_len = len(hash_digest) * 8
     L_n = order.bit_length() # use the L_n leftmost bits of the hash
     n = (h_len - L_n) if h_len >= L_n else 0

--- a/btclib/ecssa.py
+++ b/btclib/ecssa.py
@@ -4,10 +4,11 @@
 """
 
 from hashlib import sha256
-from btclib.ellipticcurves import EllipticCurve, Union, Tuple, Optional, \
+from btclib.ellipticcurves import Union, Tuple, Optional, \
                                   Scalar as PrvKey, \
                                   Point as PubKey, GenericPoint as GenericPubKey, \
                                   mod_inv, \
+                                  EllipticCurve, \
                                   int_from_Scalar, tuple_from_Point, bytes_from_Point
 from btclib.rfc6979 import rfc6979
 from btclib.ecsignutils import Message, Signature, int_from_hash
@@ -18,47 +19,50 @@ from btclib.ecsignutils import Message, Signature, int_from_hash
 
 # different structure, cannot compute e (int) before ecssa_sign_raw
 
-def ecssa_sign(ec: EllipticCurve, m: Message, prvkey: PrvKey, eph_prv: Optional[PrvKey] = None, hasher = sha256) -> Signature:
+def ecssa_sign(ec: EllipticCurve, m: Message, q: PrvKey, eph_prv: Optional[PrvKey] = None, hasher = sha256) -> Signature:
+    assert ec.return_prime() % 4 == 3, 'not a proper curve, the relation p = 3 (mod 4) must hold'
     if type(m) == str: m = hasher(m.encode()).digest()
-    prvkey = int_from_Scalar(ec, prvkey)
-    eph_prv = rfc6979(prvkey, m, hasher) if eph_prv is None else int_from_Scalar(ec, eph_prv)
-    return ecssa_sign_raw(ec, m, prvkey, eph_prv, hasher) # FIXME: this is just the message hasher
+    q = int_from_Scalar(ec, q)
+    eph_prv = rfc6979(q, m, hasher) if eph_prv is None else int_from_Scalar(ec, eph_prv)
+    return ecssa_sign_raw(ec, m, q, eph_prv, hasher) # FIXME: this is just the message hasher
 
 # https://eprint.iacr.org/2018/068
-def ecssa_sign_raw(ec: EllipticCurve, m: bytes, prvkey: int, eph_prv: int, hasher = sha256) -> Signature:
-    R = ec.pointMultiply(eph_prv, ec.G)
+def ecssa_sign_raw(ec: EllipticCurve, m: bytes, q: int, eph_prv: int, hasher = sha256) -> Signature:
+    K = ec.pointMultiply(eph_prv, ec.G)
+    assert K != None, 'sign fail'
     # break the simmetry: any criteria could be used, jacobi is standard
-    if ec.jacobi(R[1]) != 1:
+    if ec.jacobi(K[1]) != 1:
         # no need to actually change R[1], as it is not used anymore
         # let's fix eph_prv instead, as it is used later
         eph_prv = ec.n - eph_prv
-    e = hasher(R[0].to_bytes(32, byteorder="big") +
-               bytes_from_Point(ec, ec.pointMultiply(prvkey, ec.G), True) +
+    e = hasher(K[0].to_bytes(ec.bytesize, byteorder="big") +
+               bytes_from_Point(ec, ec.pointMultiply(q, ec.G), True) +
                m).digest()
-    e = int_from_hash(e, ec.n)
-    assert e != 0 and e < ec.n, "sign fail"
-    s = (eph_prv + e * prvkey) % ec.n
-    return R[0], s
+    e = int_from_hash(e, ec.n) % ec.n
+    assert e != 0, "sign fail"
+    s = (eph_prv + e * q) % ec.n
+    assert s != 0, "sign fail"
+    return K[0], s
 
 
-def ecssa_verify(ec: EllipticCurve, m: Message, ssasig: Signature, pubkey: GenericPubKey, hasher = sha256) -> bool:
+def ecssa_verify(ec: EllipticCurve, m: Message, ssasig: Signature, Q: GenericPubKey, hasher = sha256) -> bool:
     if type(m) == str: m = hasher(m.encode()).digest()
     check_ssasig(ec, ssasig)
-    pubkey =  tuple_from_Point(ec, pubkey)
-    return ecssa_verify_raw(ec, m, ssasig, pubkey, hasher) # FIXME: this is just the message hasher
+    Q =  tuple_from_Point(ec, Q)
+    return ecssa_verify_raw(ec, m, ssasig, Q, hasher) # FIXME: this is just the message hasher
 
 
-def ecssa_verify_raw(ec: EllipticCurve, m: bytes, ssasig: Signature, pub: PubKey, hasher = sha256) -> bool:
+def ecssa_verify_raw(ec: EllipticCurve, m: bytes, ssasig: Signature, Q: PubKey, hasher = sha256) -> bool:
     r, s = ssasig
-    e = hasher(r.to_bytes(32, byteorder="big") + bytes_from_Point(ec, pub, True) + m).digest()
-    e = int_from_hash(e, ec.n)
-    if e == 0 or e >= ec.n:
+    if r >= ec.return_prime():
         return False
+    e = hasher(r.to_bytes(ec.bytesize, byteorder="big") + bytes_from_Point(ec, Q, True) + m).digest()
+    e = int_from_hash(e, ec.n) % ec.n
     # R = sG - eP
-    R = ec.pointAdd(ec.pointMultiply(s, ec.G), ec.pointMultiply(ec.n - e, pub))
-    if ec.jacobi(R[1]) != 1:
+    K = ec.pointAdd(ec.pointMultiply(s, ec.G), ec.pointMultiply(ec.n - e, Q))
+    if K is None or ec.jacobi(K[1]) != 1:
         return False
-    return R[0] == ssasig[0]
+    return K[0] == ssasig[0]
 
 
 def ecssa_pubkey_recovery(ec: EllipticCurve, e: bytes, ssasig: Signature, hasher = sha256) -> PubKey:
@@ -69,12 +73,12 @@ def ecssa_pubkey_recovery(ec: EllipticCurve, e: bytes, ssasig: Signature, hasher
 
 def ecssa_pubkey_recovery_raw(ec: EllipticCurve, e: bytes, ssasig: Signature) -> PubKey:
     r, s = ssasig
-    R = (r, ec.yQuadraticResidue(r, True))
-    e = int_from_hash(e, ec.n)
-    assert e != 0 and e < ec.n, "invalid challenge e"
+    K = (r, ec.yQuadraticResidue(r, True))
+    e = int_from_hash(e, ec.n) % ec.n
+    assert e != 0, "invalid challenge e"
     e1 = mod_inv(e, ec.n)
     return ec.pointAdd(ec.pointMultiply((e1 * s) % ec.n, ec.G),
-                       ec.pointMultiply(ec.n - e1, R))
+                       ec.pointMultiply(ec.n - e1, K))
 
 
 def check_ssasig(ec: EllipticCurve, ssasig: Signature) -> bool:

--- a/btclib/ellipticcurves.py
+++ b/btclib/ellipticcurves.py
@@ -47,6 +47,9 @@ class EllipticCurve:
         Inf = self.pointAdd(T, self.G)
         assert Inf is None, "wrong order"
 
+    def return_prime(self) -> int:
+        return self.__p
+
     def assertPointCoordinate(self, c: int) -> None:
         assert type(c) == int,  "non-int point coordinate"
         assert 0 <= c, "point coordinate %s < 0" % c

--- a/btclib/numbertheory.py
+++ b/btclib/numbertheory.py
@@ -12,7 +12,6 @@ def mod_inv(a: int, m: int) -> int:
 
     # At this point, d is the GCD, and ud*a+vd*m = d.
     # If d == 1, this means that ud is a inverse.
-
     assert d == 1
     if ud > 0: return ud
     else: return ud + m

--- a/btclib/pbkdf2.py
+++ b/btclib/pbkdf2.py
@@ -57,17 +57,20 @@ from random import randint
 import string
 import sys
 
-try:
-    # Use PyCrypto (if available).
-    from Crypto.Hash import HMAC, SHA as SHA1
-except ImportError:
-    # PyCrypto not available.  Use the Python standard library.
-    import hmac as HMAC
-    try:
-        from hashlib import sha1 as SHA1
-    except ImportError:
-        # hashlib not available.  Use the old sha module.
-        import sha as SHA1
+# try:
+#     # Use PyCrypto (if available).
+#     from Crypto.Hash import HMAC, SHA as SHA1
+# except ImportError:
+#     # PyCrypto not available.  Use the Python standard library.
+#     import hmac as HMAC
+#     try:
+#         from hashlib import sha1 as SHA1
+#     except ImportError:
+#         # hashlib not available.  Use the old sha module.
+#         import sha as SHA1
+
+import hmac as HMAC
+from hashlib import sha1 as SHA1
 
 #
 # Python 2.1 thru 3.2 compatibility

--- a/btclib/rfc6979.py
+++ b/btclib/rfc6979.py
@@ -44,7 +44,7 @@ def check_hash_digest(m, hash_digest_size=default_hash_digest_size):
     """check that m is a bytes message with correct length
     """
     assert type(m) == bytes
-    assert len(m) == hash_digest_size, "m must be bytes with correct bytes length"
+    assert len(m) <= hash_digest_size, "m must be bytes with correct bytes length"
 
 def rfc6979(prv, m, hasher=default_hasher) -> int:
     assert type(prv) == int

--- a/tests/test_ecdsa.py
+++ b/tests/test_ecdsa.py
@@ -3,7 +3,7 @@
 import unittest
 from btclib.ecdsa import ecdsa_sign, ecdsa_verify, ecdsa_pubkey_recovery
 from btclib.ellipticcurves import pointMultiply, secp256k1 as ec
-from tests.test_ellipticcurves import lowcard, smallcurves
+from tests.test_ellipticcurves import lowcard
 from btclib.rfc6979 import rfc6979
 from hashlib import sha256 as hasher
 from btclib.ecsignutils import int_from_hash

--- a/tests/test_ecdsa.py
+++ b/tests/test_ecdsa.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python3
 
 import unittest
-from btclib.ecdsa import ec, ecdsa_sign, ecdsa_verify, ecdsa_pubkey_recovery
+from btclib.ecdsa import ecdsa_sign, ecdsa_verify, ecdsa_pubkey_recovery
+from btclib.ellipticcurves import pointMultiply, secp256k1 as ec
+from tests.test_ellipticcurves import lowcard, smallcurves
+from btclib.rfc6979 import rfc6979
+from hashlib import sha256 as hasher
+from btclib.ecsignutils import int_from_hash
+from btclib.ellipticcurves import mod_inv
 
 class TestEcdsa(unittest.TestCase):
     def test_ecdsa(self):
-        prv = 0x1
-        pub = ec.pointMultiply(prv, ec.G)
+        q = 0x1
+        Q = ec.pointMultiply(q, ec.G)
         msg = 'Satoshi Nakamoto'
 
-        dsasig = ecdsa_sign(msg, prv)
-        self.assertTrue(ecdsa_verify(msg, dsasig, pub))
+        dsasig = ecdsa_sign(ec, msg, q)
+        self.assertTrue(ecdsa_verify(ec, msg, dsasig, Q))
         # malleability
         malleated_sig = (dsasig[0], ec.n - dsasig[1])
-        self.assertTrue(ecdsa_verify(msg, malleated_sig, pub))
+        self.assertTrue(ecdsa_verify(ec, msg, malleated_sig, Q))
 
-        keys = (ecdsa_pubkey_recovery(msg, dsasig, 0),
-                ecdsa_pubkey_recovery(msg, dsasig, 1))
-        self.assertIn(pub, keys)
+        keys = ecdsa_pubkey_recovery(ec, msg, dsasig)
+        self.assertIn(Q, keys)
 
         # source: https://bitcointalk.org/index.php?topic=285142.40
         exp_sig = (0x934b1ea10a4b3c1757e2b0c017d0b6143ce3c9a7e6a4a49860d7a6ab210ee3d8,
@@ -27,7 +32,48 @@ class TestEcdsa(unittest.TestCase):
         sigs = (exp_sig[1], ec.n - exp_sig[1])
         self.assertIn(s, sigs)
 
+    # test all msg/key pairs on low cardinality curves
+    def test_low_cardinality(self):
+        # curve.n has to be prime to sign
+        prime = [2,	3, 5, 7, 11, 13, 17, 19, 23, 29,
+                 31, 37, 41, 43, 47, 53, 59, 61, 67, 
+                 71, 73, 79, 83, 89, 97, 101, 103, 107,
+             	 109, 113, 127,	131, 137, 139, 149,	151,
+            	 157, 163, 167,	173, 179, 181, 191, 193,
+                 197, 199, 211,	223, 227, 229, 233, 239,
+                 241, 251, 257, 263, 269, 271, 277,	281,
+                 283, 293, 307,	311, 313, 317, 331, 337]
+        for curve in lowcard:
+            if curve.n in prime:
+                for m in range(0, curve.n):
+                    # message in bytes
+                    m = m.to_bytes(curve.bytesize, 'big')
+                    for q in range(1, curve.n):
+                        Q = pointMultiply(curve, q, curve.G)
+                        # looking if the signature fails
+                        k = rfc6979(q, m, hasher)
+                        K = pointMultiply(curve, k, curve.G)
 
+                        if K == None:
+                            self.assertRaises(AssertionError, ecdsa_sign, curve, m, q)
+                        else:
+                            r = K[0] % curve.n
+                            e = int_from_hash(m, curve.n)
+                            s = mod_inv(k, curve.n) * (e + q * r) % curve.n
+                            if r == 0 or s == 0:
+                                self.assertRaises(AssertionError, ecdsa_sign, curve, m, q)
+                            else:
+                                # valid signature, must validate
+                                self.assertTrue(K != None and r != 0 and s != 0)
+                                dsasig = ecdsa_sign(curve, m, q)
+                                self.assertTrue(ecdsa_verify(curve, m, dsasig, Q))
+                                # malleability
+                                malleated_sig = (dsasig[0], curve.n - dsasig[1])
+                                self.assertTrue(ecdsa_verify(curve, m, malleated_sig, Q))
+
+                                # key recovery
+                                keys = ecdsa_pubkey_recovery(curve, m, dsasig)
+                                self.assertIn(Q, keys)
 
 if __name__ == "__main__":
     # execute only if run as a script

--- a/tests/test_ecsigntocontract.py
+++ b/tests/test_ecsigntocontract.py
@@ -14,11 +14,11 @@ class TestSignToContract(unittest.TestCase):
         c = "to be committed"
 
         sig_ecdsa, receipt_ecdsa = ecdsa_commit_and_sign(m, prv, c)
-        self.assertTrue(ecdsa_verify(m, sig_ecdsa, pub))
+        self.assertTrue(ecdsa_verify(ec, m, sig_ecdsa, pub))
         self.assertTrue(verify_commit(receipt_ecdsa, c))
 
         sig_ecssa, receipt_ecssa = ecssa_commit_and_sign(m, prv, c)
-        self.assertTrue(ecssa_verify(m, sig_ecssa, pub))
+        self.assertTrue(ecssa_verify(ec, m, sig_ecssa, pub))
         self.assertTrue(verify_commit(receipt_ecssa, c))
 
 

--- a/tests/test_ecssa.py
+++ b/tests/test_ecssa.py
@@ -2,8 +2,13 @@
 
 import unittest
 from hashlib import sha256
-from btclib.ellipticcurves import bytes_from_Point, tuple_from_Point, secp256k1 as ec
+from btclib.ellipticcurves import pointMultiply, bytes_from_Point, tuple_from_Point, secp256k1 as ec
 from btclib.ecssa import ecssa_sign, ecssa_verify, ecssa_pubkey_recovery
+from tests.test_ellipticcurves import lowcard
+from btclib.rfc6979 import rfc6979
+from hashlib import sha256 as hasher
+from btclib.ecsignutils import int_from_hash
+
 
 # https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki
 
@@ -111,6 +116,61 @@ class TestEcssa(unittest.TestCase):
                0x1E51A22CCEC35599B8F266912281F8365FFC2D035A230434A1A64DC59F7013FD)
 
         self.assertFalse(ecssa_verify(ec, msg, sig, pub))
+
+    def test_low_cardinality(self):
+        prime = [2,	3, 5, 7, 11, 13, 17, 19, 23, 29,
+                 31, 37, 41, 43, 47, 53, 59, 61, 67, 
+                 71, 73, 79, 83, 89, 97, 101, 103, 107,
+             	 109, 113, 127,	131, 137, 139, 149,	151,
+            	 157, 163, 167,	173, 179, 181, 191, 193,
+                 197, 199, 211,	223, 227, 229, 233, 239,
+                 241, 251, 257, 263, 269, 271, 277,	281,
+                 283, 293, 307,	311, 313, 317, 331, 337]
+        for curve in lowcard:
+            for m in range(0, curve.n):
+                # message in bytes
+                m = m.to_bytes(curve.bytesize, 'big')
+                for q in range(1, curve.n):
+                    Q = pointMultiply(curve, q, curve.G)
+                    # can we apply the procedure presented in Schnorr BIP?
+                    if curve.return_prime() % 4 == 1:
+                        self.assertRaises(AssertionError, ecssa_sign, curve, m, q)
+                    else:
+                        self.assertTrue(curve.return_prime() % 4 == 3)
+                        k = rfc6979(q, m, hasher)
+                        K = pointMultiply(curve, k, curve.G)
+                        
+                        # looking if the signature fails
+                        if K == None:
+                            self.assertRaises(AssertionError, ecssa_sign, curve, m, q)
+                        else:
+                            if curve.jacobi(K[1]) != 1:
+                                k = curve.n - k
+                            e = hasher(K[0].to_bytes(curve.bytesize, byteorder="big") +
+                                bytes_from_Point(curve, pointMultiply(curve, q, curve.G), True) +
+                               m).digest()
+                            e = int_from_hash(e, curve.n) % curve.n
+                            s = (k + e * q) % curve.n
+
+                            if e == 0 or s == 0:
+                                self.assertRaises(AssertionError, ecssa_sign, curve, m, q)
+                            else:
+                                # valid signature, must validate
+                                self.assertTrue(K != None and e != 0 and s != 0)
+                                sig = ecssa_sign(curve, m, q)
+                                self.assertTrue(ecssa_verify(curve, m, sig, Q))
+                                # not malleable
+                                malleated_sig = (sig[0], curve.n - sig[1])
+                                self.assertFalse(ecssa_verify(curve, m, malleated_sig, Q))
+
+                                # key recovery: works only if p is prime and p = 3 (mod 4)
+                                if curve.return_prime() in prime:
+                                    e = hasher(K[0].to_bytes(curve.bytesize, byteorder="big") +
+                                               bytes_from_Point(curve, pointMultiply(curve, q, curve.G), True) +
+                                               m).digest()
+                                    key = ecssa_pubkey_recovery(curve, e, sig)
+                                    self.assertTrue(Q == key)
+
 
 
 if __name__ == "__main__":

--- a/tests/test_ecssa.py
+++ b/tests/test_ecssa.py
@@ -2,8 +2,8 @@
 
 import unittest
 from hashlib import sha256
-from btclib.ellipticcurves import bytes_from_Point, tuple_from_Point
-from btclib.ecssa import ec, ecssa_sign, ecssa_verify, ecssa_pubkey_recovery
+from btclib.ellipticcurves import bytes_from_Point, tuple_from_Point, secp256k1 as ec
+from btclib.ecssa import ecssa_sign, ecssa_verify, ecssa_pubkey_recovery
 
 # https://github.com/sipa/bips/blob/bip-schnorr/bip-schnorr.mediawiki
 
@@ -16,15 +16,15 @@ class TestEcssa(unittest.TestCase):
                         0x7031A98831859DC34DFFEEDDA86831842CCD0079E1F92AF177F7F22CC1DCED05)
         eph_prv = int.from_bytes(sha256(prv.to_bytes(32, byteorder="big") + msg).digest(), byteorder="big")
 
-        sig = ecssa_sign(msg, prv, eph_prv)
-        self.assertTrue(ecssa_verify(msg, sig, pub))
+        sig = ecssa_sign(ec, msg, prv, eph_prv)
+        self.assertTrue(ecssa_verify(ec, msg, sig, pub))
         # malleability
-        self.assertFalse(ecssa_verify(msg, (sig[0], ec.n - sig[1]), pub))
+        self.assertFalse(ecssa_verify(ec, msg, (sig[0], ec.n - sig[1]), pub))
         self.assertEqual(sig, expected_sig)
         e = sha256(sig[0].to_bytes(32, byteorder="big") +
                    bytes_from_Point(ec, pub, True) +
                    msg).digest()
-        self.assertEqual(ecssa_pubkey_recovery(e, sig), pub)
+        self.assertEqual(ecssa_pubkey_recovery(ec, e, sig), pub)
 
     def test_ecssa_2(self):
         prv = 0xB7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF
@@ -34,15 +34,15 @@ class TestEcssa(unittest.TestCase):
                         0x1E51A22CCEC35599B8F266912281F8365FFC2D035A230434A1A64DC59F7013FD)
         eph_prv = int.from_bytes(sha256(prv.to_bytes(32, byteorder="big") + msg).digest(), byteorder="big")
 
-        sig = ecssa_sign(msg, prv, eph_prv)
-        self.assertTrue(ecssa_verify(msg, sig, pub))
+        sig = ecssa_sign(ec, msg, prv, eph_prv)
+        self.assertTrue(ecssa_verify(ec, msg, sig, pub))
         # malleability
-        self.assertFalse(ecssa_verify(msg, (sig[0], ec.n - sig[1]), pub))
+        self.assertFalse(ecssa_verify(ec, msg, (sig[0], ec.n - sig[1]), pub))
         self.assertEqual(sig, expected_sig)
         e = sha256(sig[0].to_bytes(32, byteorder="big") +
                    bytes_from_Point(ec, pub, True) +
                    msg).digest()
-        self.assertEqual(ecssa_pubkey_recovery(e, sig), pub)
+        self.assertEqual(ecssa_pubkey_recovery(ec, e, sig), pub)
 
     def test_ecssa_3(self):
         prv = 0xC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B14E5C7
@@ -52,15 +52,15 @@ class TestEcssa(unittest.TestCase):
                         0x00880371D01766935B92D2AB4CD5C8A2A5837EC57FED7660773A05F0DE142380)
         eph_prv = int.from_bytes(sha256(prv.to_bytes(32, byteorder="big") + msg).digest(), byteorder="big")
 
-        sig = ecssa_sign(msg, prv, eph_prv)
-        self.assertTrue(ecssa_verify(msg, sig, pub))
+        sig = ecssa_sign(ec, msg, prv, eph_prv)
+        self.assertTrue(ecssa_verify(ec, msg, sig, pub))
         # malleability
-        self.assertFalse(ecssa_verify(msg, (sig[0], ec.n - sig[1]), pub))
+        self.assertFalse(ecssa_verify(ec, msg, (sig[0], ec.n - sig[1]), pub))
         self.assertEqual(sig, expected_sig)
         e = sha256(sig[0].to_bytes(32, byteorder="big") +
                    bytes_from_Point(ec, pub, True) +
                    msg).digest()
-        self.assertEqual(ecssa_pubkey_recovery(e, sig), pub)
+        self.assertEqual(ecssa_pubkey_recovery(ec, e, sig), pub)
 
     def test_ecssa_4(self):
         pub = tuple_from_Point(ec, "03DEFDEA4CDB677750A420FEE807EACF21EB9898AE79B9768766E4FAA04A2D4A34")
@@ -68,13 +68,13 @@ class TestEcssa(unittest.TestCase):
         sig = (0x00000000000000000000003B78CE563F89A0ED9414F5AA28AD0D96D6795F9C63,
                0x02A8DC32E64E86A333F20EF56EAC9BA30B7246D6D25E22ADB8C6BE1AEB08D49D)
 
-        self.assertTrue(ecssa_verify(msg, sig, pub))
+        self.assertTrue(ecssa_verify(ec, msg, sig, pub))
         # malleability
-        self.assertFalse(ecssa_verify(msg, (sig[0], ec.n - sig[1]), pub))
+        self.assertFalse(ecssa_verify(ec, msg, (sig[0], ec.n - sig[1]), pub))
         e = sha256(sig[0].to_bytes(32, byteorder="big") +
                    bytes_from_Point(ec, pub, True) +
                    msg).digest()
-        self.assertEqual(ecssa_pubkey_recovery(e, sig), pub)
+        self.assertEqual(ecssa_pubkey_recovery(ec, e, sig), pub)
 
     def test_ecssa_5(self):
         """Incorrect sig: incorrect R residuosity"""
@@ -83,7 +83,7 @@ class TestEcssa(unittest.TestCase):
         sig = (0x2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D,
                0xFA16AEE06609280A19B67A24E1977E4697712B5FD2943914ECD5F730901B4AB7)
 
-        self.assertFalse(ecssa_verify(msg, sig, pub))
+        self.assertFalse(ecssa_verify(ec, msg, sig, pub))
 
     def test_ecssa_6(self):
         """Incorrect sig: negated message hash"""
@@ -92,7 +92,7 @@ class TestEcssa(unittest.TestCase):
         sig = (0x00DA9B08172A9B6F0466A2DEFD817F2D7AB437E0D253CB5395A963866B3574BE,
                0xD092F9D860F1776A1F7412AD8A1EB50DACCC222BC8C0E26B2056DF2F273EFDEC)
 
-        self.assertFalse(ecssa_verify(msg, sig, pub))
+        self.assertFalse(ecssa_verify(ec, msg, sig, pub))
 
     def test_ecssa_7(self):
         """Incorrect sig: negated s value"""
@@ -101,7 +101,7 @@ class TestEcssa(unittest.TestCase):
         sig = (0x787A848E71043D280C50470E8E1532B2DD5D20EE912A45DBDD2BD1DFBF187EF6,
                0x8FCE5677CE7A623CB20011225797CE7A8DE1DC6CCD4F754A47DA6C600E59543C)
 
-        self.assertFalse(ecssa_verify(msg, sig, pub))
+        self.assertFalse(ecssa_verify(ec, msg, sig, pub))
 
     def test_ecssa_8(self):
         """Incorrect sig: negated public key"""
@@ -110,7 +110,7 @@ class TestEcssa(unittest.TestCase):
         sig = (0x2A298DACAE57395A15D0795DDBFD1DCB564DA82B0F269BC70A74F8220429BA1D,
                0x1E51A22CCEC35599B8F266912281F8365FFC2D035A230434A1A64DC59F7013FD)
 
-        self.assertFalse(ecssa_verify(msg, sig, pub))
+        self.assertFalse(ecssa_verify(ec, msg, sig, pub))
 
 
 if __name__ == "__main__":

--- a/tests/test_ecssamusig.py
+++ b/tests/test_ecssamusig.py
@@ -11,7 +11,8 @@ https://medium.com/@snigirev.stepan/how-schnorr-signatures-may-improve-bitcoin-9
 
 import unittest
 from btclib.ellipticcurves import int_from_Scalar, bytes_from_Point
-from btclib.ecssa import sha256, ec, int_from_hash, ecssa_verify
+from btclib.ecssa import sha256, int_from_hash, ecssa_verify
+from btclib.ellipticcurves import secp256k1 as ec
 
 class TestEcssaMuSig(unittest.TestCase):
 
@@ -90,7 +91,7 @@ class TestEcssaMuSig(unittest.TestCase):
         s_All = (s1 + s2) % ec.n
         ssasig = (R1_All[0], s_All)
 
-        self.assertTrue(ecssa_verify(msg, ssasig, Q_All, sha256))
+        self.assertTrue(ecssa_verify(ec, msg, ssasig, Q_All, sha256))
 
 
 if __name__ == "__main__":

--- a/tests/test_ellipticcurves.py
+++ b/tests/test_ellipticcurves.py
@@ -129,10 +129,37 @@ ec283_281 = EllipticCurve(2, 7, 283, (0,  63), 281)
 ec293_281 = EllipticCurve(8, 6, 293, (0,  42), 281)
 ec293_311 = EllipticCurve(1, 4, 293, (0, 291), 311)
 
-allcurves = [
-    secp192k1, secp192r1, secp224k1, secp224r1,
-    secp256k1, secp256r1, secp384r1, secp521r1,
-    ec11_13, ec263_269, ec263_270, ec263_280,
+lowcard = [
+    ec11_13, 
+    ec11_7, ec11_17,
+    ec13_11, ec13_19,
+    ec17_13, ec17_23,
+    ec19_13, ec19_23,
+    ec23_19, ec23_31,
+    ec29_37,
+    ec31_23, ec31_43,
+    ec37_31, ec37_43,
+    ec41_37, ec41_53,
+    ec43_37, ec43_47,
+    ec47_41, ec47_61,
+    ec53_47, ec53_61,
+    ec59_53, ec59_73,
+    ec61_59, ec61_73,
+    ec67_61, ec67_83,
+    ec71_67, ec71_79,
+    ec73_61, ec73_83,
+    ec79_71, ec79_97,
+    ec83_79, ec83_101,
+    ec89_83, ec89_101,
+    ec97_89, ec97_103,
+    ec101_97, #ec101_101,
+    ec103_101
+
+]
+
+smallcurves = [
+    ec11_13, ec263_269, 
+    ec263_270, ec263_280,
     ec11_7, ec11_17,
     ec13_11, ec13_19,
     ec17_13, ec17_23,
@@ -189,7 +216,13 @@ allcurves = [
     ec277_263, ec277_307,
     ec281_311,
     ec283_281, #ec283_283,
-    ec293_281, ec293_311]
+    ec293_281, ec293_311
+    ]
+
+allcurves = [
+    secp192k1, secp192r1, secp224k1, secp224r1,
+    secp256k1, secp256r1, secp384r1, secp521r1] + smallcurves
+    
 
 class TestEllipticCurve(unittest.TestCase):
     def test_all_curves(self):


### PR DESCRIPTION
Added a couple of tests (ECDSA/Schnorr) to check signatures on low cardinality curves, adapted the notation to the one of the institute and fixed some minor inconsistencies that arose with the new code structure.